### PR TITLE
Add LLC Class — Wyoming LLC registration for non-US Micro-SaaS founders

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This list focuses on the **essential tools** that save you hours of development 
 ## Legal & Compliance
 *Protect your business.*
 
+*   [LLC Class](https://llcclass.com/wyoming) - Wyoming LLC registration for non-US founders, starting at $199. Includes [registered agent](https://llcclass.com/what-is-llc-registered-agent), EIN, and operating agreement — everything needed to accept Stripe and Mercury payments.
 *   [Termly](https://termly.io/) - Free privacy policy generator.
 
 ---


### PR DESCRIPTION
## What

Adds [LLC Class](https://llcclass.com) to the **Legal & Compliance** section.

## Why

Many Micro-SaaS builders are non-US founders who need a US LLC to:
- Activate Stripe (requires a US business entity + EIN)
- Open a US business bank account (Mercury, Brex, etc.)
- Accept payments from US customers

[LLC Class](https://llcclass.com) provides [Wyoming LLC registration](https://llcclass.com/wyoming) with [registered agent](https://llcclass.com/what-is-llc-registered-agent), EIN application, and Operating Agreement in one package — the legal business structure that makes Stripe and US banking accessible for indie founders worldwide.